### PR TITLE
refactor: Unify all profile picture handling to Cloudinary

### DIFF
--- a/src/main/java/com/app/shopin/modules/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/app/shopin/modules/security/service/CustomOAuth2UserService.java
@@ -5,8 +5,7 @@ import com.app.shopin.modules.security.entity.Rol;
 import com.app.shopin.modules.security.enums.RolName;
 import com.app.shopin.modules.user.entity.User;
 import com.app.shopin.modules.user.repository.UserRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.app.shopin.services.cloudinary.StorageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
@@ -16,10 +15,10 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-// --- CAMBIO 1: Extiende OidcUserService ---
 @Service
 public class CustomOAuth2UserService extends OidcUserService {
 
@@ -29,20 +28,16 @@ public class CustomOAuth2UserService extends OidcUserService {
     private RolService rolService;
     @Autowired
     private PasswordEncoder passwordEncoder;
+    @Autowired
+    private StorageService storageService;
 
-    private static final Logger logger = LoggerFactory.getLogger(CustomOAuth2UserService.class);
-
-    // --- CAMBIO 2: El método ahora trabaja con OIDC ---
     @Override
     public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
-        System.out.println("\n\n****** ¡AHORA SÍ! El método OIDC loadUser se está ejecutando ******\n\n");
 
         OidcUser oidcUser = super.loadUser(userRequest);
         String email = oidcUser.getAttribute("email");
-        logger.info("Iniciando proceso de loadUser OIDC para el email: {}", email);
 
         User user = userRepository.findByEmail(email).orElseGet(() -> {
-            logger.info("Usuario con email {} no encontrado. Creando uno nuevo.", email);
             String firstName = oidcUser.getAttribute("given_name");
             String lastName = oidcUser.getAttribute("family_name");
             String pictureUrl = oidcUser.getAttribute("picture");
@@ -55,19 +50,26 @@ public class CustomOAuth2UserService extends OidcUserService {
             newUser.setProfilePictureUrl(pictureUrl);
             newUser.setPassword(passwordEncoder.encode(UUID.randomUUID().toString()));
 
+            try {
+                String googlePictureUrl = oidcUser.getAttribute("picture");
+                if (googlePictureUrl != null && !googlePictureUrl.isEmpty()) {
+                    Map<String, String> fileInfo = storageService.uploadFromUrl(googlePictureUrl, "profileimages");
+                    newUser.setProfilePictureUrl(fileInfo.get("url"));
+                    newUser.setProfilePicturePublicId(fileInfo.get("publicId"));
+                }
+            } catch (Exception e) {
+                // Opcional: podrías generar un avatar aquí como fallback
+            }
+
             Set<Rol> roles = new HashSet<>();
             Rol userRole = rolService.getByRolName(RolName.ROLE_USER)
                     .orElseThrow(() -> new RuntimeException("FATAL: Rol 'ROLE_USER' no encontrado."));
             roles.add(userRole);
             newUser.setRoles(roles);
 
-            logger.info("Guardando nuevo usuario OIDC con email: {}", email);
             return userRepository.save(newUser);
         });
 
-        logger.info("Usuario OIDC procesado para email: {}", user.getEmail());
-
-        // --- CAMBIO 3: Usamos el nuevo método build para crear nuestro PrincipalUser ---
         return PrincipalUser.build(user, oidcUser);
     }
 }

--- a/src/main/java/com/app/shopin/services/cloudinary/StorageService.java
+++ b/src/main/java/com/app/shopin/services/cloudinary/StorageService.java
@@ -1,16 +1,14 @@
 package com.app.shopin.services.cloudinary;
 
-import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public interface StorageService {
 
     Map<String, String> saveFile(MultipartFile file, String filename, String subfolder);
 
+    Map<String, String> uploadFromUrl(String url, String subfolder);
     void deleteFile(String publicId, String subfolder);
 
     boolean isImageFile(MultipartFile file);


### PR DESCRIPTION
The use of profile images for users was unified, now it does not matter if it is a profile image of a Google account or a created avatar (not established profile image or it was eliminated) In both cases the physical image in Cloudinary is created for its better management and standardization of size (96x96)